### PR TITLE
헤로쿠에 배포하기 - DB변경 (ClearDB -> JawsDB)

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,7 +63,7 @@ spring:
     activate:
       on-profile: heroku
   datasource:
-    url: ${CLEARDB_DATABASE_URL}
+    url: ${JAWSDB_URL}
   jpa:
     hibernate:
       ddl-auto: create


### PR DESCRIPTION
조사해본 결과, cleardb 의 기본 mysql 버전이 5.6으로 너무 낮기 때문에 문제가 발생한 것으로 확인함 (5.6 버전에서는 article_comment.content 인덱스 사이즈가 너무 큼)
대안으로 jawsdb 를 찾아냄. 기본 mysql 버전이 8.0.
이를 이용해 환경변수를 다시 작업함

This fixes #39 

* https://devcenter.heroku.com/articles/jawsdb#provisioning-with-custom-options
* https://devcenter.heroku.com/articles/cleardb#the-cleardb-dedicated-mysql-complete-tutorial-local-setup